### PR TITLE
[BC Scanner] Move to nutsdb repos

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -24,11 +24,14 @@ require (
 	google.golang.org/protobuf v1.28.0
 )
 
+require github.com/xujiajun/nutsdb v0.10.0
+
 require (
 	github.com/aead/siphash v1.0.1 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/btcsuite/btcd/btcutil/psbt v1.1.4 // indirect
 	github.com/btcsuite/btclog v0.0.0-20170628155309-84c8d2346e9f // indirect
+	github.com/bwmarrin/snowflake v0.3.0 // indirect
 	github.com/cespare/xxhash v1.1.0 // indirect
 	github.com/cespare/xxhash/v2 v2.1.2 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
@@ -67,8 +70,10 @@ require (
 	github.com/tyler-smith/go-bip39 v1.1.0 // indirect
 	github.com/vulpemventures/fastsha256 v0.0.0-20160815193821-637e65642941 // indirect
 	github.com/vulpemventures/go-secp256k1-zkp v1.1.5 // indirect
+	github.com/xujiajun/mmap-go v1.0.1 // indirect
+	github.com/xujiajun/utils v0.0.0-20190123093513-8bf096c4f53b // indirect
 	go.opencensus.io v0.23.0 // indirect
-	golang.org/x/sys v0.0.0-20220608164250-635b8c9b7f68 // indirect
+	golang.org/x/sys v0.0.0-20220825204002-c680a09ffe64 // indirect
 	golang.org/x/text v0.3.7 // indirect
 	google.golang.org/genproto v0.0.0-20220519153652-3a47de7e79bd // indirect
 	gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c // indirect

--- a/go.sum
+++ b/go.sum
@@ -218,6 +218,8 @@ github.com/buger/jsonparser v1.1.1/go.mod h1:6RYKKt7H4d4+iWqouImQ9R2FZql3VbhNgx2
 github.com/bugsnag/bugsnag-go v0.0.0-20141110184014-b1d153021fcd/go.mod h1:2oa8nejYd4cQ/b0hMIopN0lCRxU0bueqREvZLWFrtK8=
 github.com/bugsnag/osext v0.0.0-20130617224835-0dd3f918b21b/go.mod h1:obH5gd0BsqsP2LwDJ9aOkm/6J86V6lyAXCoQWGw3K50=
 github.com/bugsnag/panicwrap v0.0.0-20151223152923-e2c28503fcd0/go.mod h1:D/8v3kj0zr8ZAKg1AQ6crr+5VwKN5eIywRkfhyM/+dE=
+github.com/bwmarrin/snowflake v0.3.0 h1:xm67bEhkKh6ij1790JB83OujPR5CzNe8QuQqAgISZN0=
+github.com/bwmarrin/snowflake v0.3.0/go.mod h1:NdZxfVWX+oR6y2K0o6qAYv6gIOP9rjG0/E9WsDpxqwE=
 github.com/cenkalti/backoff/v4 v4.1.1/go.mod h1:scbssz8iZGpm3xbr14ovlUdkxfGXNInqkPWOWmG2CLw=
 github.com/cenkalti/backoff/v4 v4.1.2/go.mod h1:scbssz8iZGpm3xbr14ovlUdkxfGXNInqkPWOWmG2CLw=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
@@ -1268,6 +1270,13 @@ github.com/xeipuuv/gojsonreference v0.0.0-20180127040603-bd5ef7bd5415/go.mod h1:
 github.com/xeipuuv/gojsonschema v0.0.0-20180618132009-1d523034197f/go.mod h1:5yf86TLmAcydyeJq5YvxkGPE2fm/u4myDekKRoLuqhs=
 github.com/xiang90/probing v0.0.0-20190116061207-43a291ad63a2/go.mod h1:UETIi67q53MR2AWcXfiuqkDkRtnGDLqkBTpCHuJHxtU=
 github.com/xordataexchange/crypt v0.0.3-0.20170626215501-b2862e3d0a77/go.mod h1:aYKd//L2LvnjZzWKhF00oedf4jCCReLcmhLdhm1A27Q=
+github.com/xujiajun/gorouter v1.2.0/go.mod h1:yJrIta+bTNpBM/2UT8hLOaEAFckO+m/qmR3luMIQygM=
+github.com/xujiajun/mmap-go v1.0.1 h1:7Se7ss1fLPPRW+ePgqGpCkfGIZzJV6JPq9Wq9iv/WHc=
+github.com/xujiajun/mmap-go v1.0.1/go.mod h1:CNN6Sw4SL69Sui00p0zEzcZKbt+5HtEnYUsc6BKKRMg=
+github.com/xujiajun/nutsdb v0.10.0 h1:kSxd7MyZiAVQM2I79FK74WneGI+uaHsUdak8dbjzKJc=
+github.com/xujiajun/nutsdb v0.10.0/go.mod h1:8ZdTTF0cEQO+wN940htfHYKswFql2iB6Osckx+GmOoU=
+github.com/xujiajun/utils v0.0.0-20190123093513-8bf096c4f53b h1:jKG9OiL4T4xQN3IUrhUpc1tG+HfDXppkgVcrAiiaI/0=
+github.com/xujiajun/utils v0.0.0-20190123093513-8bf096c4f53b/go.mod h1:AZd87GYJlUzl82Yab2kTjx1EyXSQCAfZDhpTo1SQC4k=
 github.com/youmark/pkcs8 v0.0.0-20181117223130-1be2e3e5546d/go.mod h1:rHwXgn7JulP+udvsHwJoVG1YGAP6VLg4y9I5dyZdqmA=
 github.com/yuin/goldmark v1.1.25/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
@@ -1552,6 +1561,7 @@ golang.org/x/sys v0.0.0-20181026203630-95b1ffbd15a5/go.mod h1:STP8DvDyc/dI5b8T5h
 golang.org/x/sys v0.0.0-20181107165924-66b7b1311ac8/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20181116152217-5ac8a444bdc5/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20181205085412-a5c9d58dba9a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
+golang.org/x/sys v0.0.0-20181221143128-b4a75ba826a6/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190222072716-a9d3bda3a223/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190312061237-fead79001313/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
@@ -1679,11 +1689,13 @@ golang.org/x/sys v0.0.0-20220209214540-3681064d5158/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.0.0-20220227234510-4e6760a101f9/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220317061510-51cd9980dadf/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220328115105-d36c6a25d886/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.0.0-20220405210540-1e041c57c461/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220412211240-33da011f77ad/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220502124256-b6088ccd6cba/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220520151302-bc2c85ada10a/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/sys v0.0.0-20220608164250-635b8c9b7f68 h1:z8Hj/bl9cOV2grsOpEaQFUaly0JWN3i97mo3jXKJNp0=
 golang.org/x/sys v0.0.0-20220608164250-635b8c9b7f68/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.0.0-20220825204002-c680a09ffe64 h1:UiNENfZ8gDvpiWw7IpOMQ27spWmThO1RwwdQVbJahJM=
+golang.org/x/sys v0.0.0-20220825204002-c680a09ffe64/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/term v0.0.0-20201117132131-f5c789dd3221/go.mod h1:Nr5EML6q2oocZ2LXRh80K7BxOlk5/8JxuGnuhpl+muw=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
 golang.org/x/term v0.0.0-20210220032956-6a3ed077a48d/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -75,7 +75,7 @@ const (
 var (
 	vip *viper.Viper
 
-	defaultDatadir            = btcutil.AppDataDir("ocean-wallet", false)
+	defaultDatadir            = btcutil.AppDataDir("oceand", false)
 	defaultDbType             = "badger"
 	defaultBcScannerType      = "neutrino"
 	defaultPort               = 18000

--- a/internal/infrastructure/blockchain-scanner/neutrino/filter_repo.go
+++ b/internal/infrastructure/blockchain-scanner/neutrino/filter_repo.go
@@ -3,66 +3,62 @@ package neutrino_scanner
 import (
 	"context"
 
-	"github.com/dgraph-io/badger/v3"
-	"github.com/timshannon/badgerhold/v4"
+	"github.com/btcsuite/btcd/btcutil"
 	"github.com/vulpemventures/neutrino-elements/pkg/repository"
+	"github.com/xujiajun/nutsdb"
 )
 
-type filterRepo struct {
-	store *badgerhold.Store
+const filterBucket = "filters"
+
+type filtersRepo struct {
+	store *nutsdb.DB
 }
 
-func NewFilterRepo(store *badgerhold.Store) repository.FilterRepository {
-	return newFilterRepo(store)
+func NewFiltersRepo(store *nutsdb.DB) repository.FilterRepository {
+	return newFiltersRepo(store)
 }
 
-func newFilterRepo(store *badgerhold.Store) *filterRepo {
-	return &filterRepo{store}
+func newFiltersRepo(store *nutsdb.DB) *filtersRepo {
+	return &filtersRepo{
+		store: store,
+	}
 }
 
-func (r *filterRepo) PutFilter(
-	ctx context.Context, entry *repository.FilterEntry,
+func (r *filtersRepo) PutFilter(
+	_ context.Context, entry *repository.FilterEntry,
 ) error {
-	var err error
-	if ctx.Value("tx") != nil {
-		t := ctx.Value("tx").(*badger.Txn)
-		err = r.store.TxInsert(t, entry.Key.String(), *entry)
-	} else {
-		err = r.store.Insert(entry.Key.String(), *entry)
-	}
-
-	if err != nil {
-		if err == badgerhold.ErrKeyExists {
-			return nil
-		}
-		return err
-	}
-	return nil
+	return r.store.Update(func(tx *nutsdb.Tx) error {
+		key := entry.Key
+		hashedKey := btcutil.Hash160(append(key.BlockHash, byte(key.FilterType)))
+		return tx.Put(filterBucket, hashedKey, entry.NBytes, nutsdb.Persistent)
+	})
 }
 
-func (r *filterRepo) GetFilter(
-	ctx context.Context, key repository.FilterKey,
+func (r *filtersRepo) GetFilter(
+	_ context.Context, key repository.FilterKey,
 ) (*repository.FilterEntry, error) {
-	var err error
-	var entry repository.FilterEntry
-
-	if ctx.Value("tx") != nil {
-		t := ctx.Value("tx").(*badger.Txn)
-		err = r.store.TxGet(t, key.String(), &entry)
-	} else {
-		err = r.store.Get(key.String(), &entry)
-	}
-
-	if err != nil {
-		if err == badgerhold.ErrNotFound {
-			return nil, repository.ErrFilterNotFound
+	var nBytes []byte
+	hashedKey := btcutil.Hash160(append(key.BlockHash, byte(key.FilterType)))
+	if err := r.store.View(func(tx *nutsdb.Tx) error {
+		e, err := tx.Get(filterBucket, hashedKey)
+		if err != nil {
+			if err == nutsdb.ErrKeyNotFound || err == nutsdb.ErrBucketEmpty {
+				return repository.ErrFilterNotFound
+			}
+			return err
 		}
+		nBytes = e.Value
+		return nil
+	}); err != nil {
 		return nil, err
 	}
 
-	return &entry, nil
+	return &repository.FilterEntry{
+		Key:    key,
+		NBytes: nBytes,
+	}, nil
 }
 
-func (r *filterRepo) close() error {
+func (r *filtersRepo) close() error {
 	return r.store.Close()
 }


### PR DESCRIPTION
This changes the implementation type of the filters and headers repos of the inner neutrino-elements blockchain scanner from badgerdb to nutsdb, which offers better performances for the embedded neutrino service ran by ocean.

