### PR TITLE
Hotfix: Watch for spent utxos

### DIFF
--- a/internal/core/application/account_service.go
+++ b/internal/core/application/account_service.go
@@ -238,6 +238,13 @@ func (as *AccountService) registerHandlerForWalletEvents() {
 			as.bcScanner.StopWatchForAccount(event.AccountName)
 		},
 	)
+	// Start watching for when utxos are spent as soon as they are added to the storage.
+	as.repoManager.RegisterHandlerForUtxoEvent(
+		domain.UtxoAdded, func(event domain.UtxoEvent) {
+			accountName := event.Utxos[0].AccountName
+			as.bcScanner.WatchForUtxos(accountName, event.Utxos)
+		},
+	)
 }
 
 func (as *AccountService) listenToUtxoChannel(

--- a/internal/core/application/account_service.go
+++ b/internal/core/application/account_service.go
@@ -11,17 +11,17 @@ import (
 )
 
 // AccountService is responsible for operations related to wallet accounts:
-// 	* Create a new account.
-// 	* Derive addresses for an existing account.
-// 	* List derived addresses for an existing account.
-// 	* Get balance of an existing account.
-// 	* List utxos of an existing account.
-// 	* Delete an existing account.
+//   - Create a new account.
+//   - Derive addresses for an existing account.
+//   - List derived addresses for an existing account.
+//   - Get balance of an existing account.
+//   - List utxos of an existing account.
+//   - Delete an existing account.
 //
 // The service registers 3 handlers related to the following wallet events:
-//	* domain.WalletAccountCreated - whenever an account is created, the service initializes a dedicated blockchain scanner and starts listening for its reports.
-//	* domain.WalletAccountAddressesDerived - whenever one or more addresses are derived for an account, they are added to the list of those watched by the account's scanner.
-//	* domain.WalletAccountDeleted - whenever an account is deleted, the relative scanner is stopped and removed.
+//   - domain.WalletAccountCreated - whenever an account is created, the service initializes a dedicated blockchain scanner and starts listening for its reports.
+//   - domain.WalletAccountAddressesDerived - whenever one or more addresses are derived for an account, they are added to the list of those watched by the account's scanner.
+//   - domain.WalletAccountDeleted - whenever an account is deleted, the relative scanner is stopped and removed.
 //
 // The service guarantees to be always listening to notifications coming from
 // each of its blockchain scanners in order to keep updated the utxo set of the
@@ -245,6 +245,18 @@ func (as *AccountService) registerHandlerForWalletEvents() {
 			as.bcScanner.WatchForUtxos(accountName, event.Utxos)
 		},
 	)
+
+	// In background, make sure to watch for all utxos to get notified when they are spent.
+	go func() {
+		utxos := as.repoManager.UtxoRepository().GetAllUtxos(
+			context.Background(),
+		)
+		for _, u := range utxos {
+			if !u.IsSpent() {
+				as.bcScanner.WatchForUtxos(u.AccountName, []domain.UtxoInfo{u.Info()})
+			}
+		}
+	}()
 }
 
 func (as *AccountService) listenToUtxoChannel(

--- a/internal/core/application/mocks_test.go
+++ b/internal/core/application/mocks_test.go
@@ -43,6 +43,32 @@ func (m *mockBcScanner) WatchForAccount(
 		}
 	}
 }
+func (m *mockBcScanner) WatchForUtxos(
+	accountName string, utxos []domain.UtxoInfo,
+) {
+	if len(utxos) > 0 {
+		list := make([]*domain.Utxo, 0, len(utxos))
+		for _, u := range utxos {
+			list = append(list, &domain.Utxo{
+				UtxoKey:         u.Key(),
+				Value:           u.Value,
+				Asset:           u.Asset,
+				Script:          u.Script,
+				AssetBlinder:    u.AssetBlinder,
+				ValueBlinder:    u.ValueBlinder,
+				SpentStatus:     u.SpentStatus,
+				ConfirmedStatus: u.ConfirmedStatus,
+				AccountName:     u.AccountName,
+			})
+		}
+		m.chUtxos <- list
+
+		for _, u := range utxos {
+			tx := randomTx(accountName, u.TxID)
+			m.chTxs <- tx
+		}
+	}
+}
 
 func (m *mockBcScanner) StopWatchForAccount(accountName string) {
 	close(m.chTxs)

--- a/internal/core/ports/blockchain_scanner.go
+++ b/internal/core/ports/blockchain_scanner.go
@@ -20,6 +20,9 @@ type BlockchainScanner interface {
 		accountName string, startingBlockHeight uint32,
 		addresses []domain.AddressInfo,
 	)
+	WatchForUtxos(
+		accountName string, utxos []domain.UtxoInfo,
+	)
 	// StopWatchForAccount instructs the scanner to stop notifying about
 	// txs/utxos related to any address belonging to the given HD account.
 	StopWatchForAccount(accountName string)

--- a/internal/infrastructure/blockchain-scanner/elements/service.go
+++ b/internal/infrastructure/blockchain-scanner/elements/service.go
@@ -107,6 +107,13 @@ func (s *service) WatchForAccount(
 	scannerSvc.watchAddresses(addressesInfo)
 }
 
+func (s *service) WatchForUtxos(
+	accountName string, utxos []domain.UtxoInfo,
+) {
+	scannerSvc := s.getOrCreateScanner(accountName, 0)
+	scannerSvc.watchUtxos(utxos)
+}
+
 func (s *service) StopWatchForAccount(accountName string) {
 	scannerSvc := s.getOrCreateScanner(accountName, 0)
 	scannerSvc.stop()

--- a/internal/infrastructure/blockchain-scanner/neutrino/service.go
+++ b/internal/infrastructure/blockchain-scanner/neutrino/service.go
@@ -129,6 +129,13 @@ func (s *service) WatchForAccount(
 	scannerSvc.watchAddresses(addressesInfo)
 }
 
+func (s *service) WatchForUtxos(
+	accountName string, utxos []domain.UtxoInfo,
+) {
+	scannerSvc := s.getOrCreateScanner(accountName, 0)
+	scannerSvc.watchUtxos(utxos)
+}
+
 func (s *service) StopWatchForAccount(accountName string) {
 	scannerSvc := s.getOrCreateScanner(accountName, 0)
 	scannerSvc.stop()


### PR DESCRIPTION
After the intergratation of ocean wallet with other services, we noticed that the wallet didn't get notified by the blockchain scanner for tx with NO new utxos but only SPENT ones.

The reason was that the currently defined blockchain scanner interface allowed only watching for new utxos. This adds a new method `WatchForUtxos` and adds logic to the account application service in order to start watching utxos as soon as they're added to the underlying repository.

Note that this kind of watch won't be persistent because as soon as a utxo has been spent, we don't need to watch for it anymore.