### PR TITLE
[Electrum] Support batch requests

### DIFF
--- a/internal/infrastructure/blockchain-scanner/electrum/client.go
+++ b/internal/infrastructure/blockchain-scanner/electrum/client.go
@@ -18,7 +18,7 @@ type electrumClient interface {
 
 	getLatestBlock() ([]byte, uint32, error)
 	getBlockInfo(height uint32) (*chainhash.Hash, int64, error)
-	getScriptHashHistory(scriptHash string) ([]txInfo, error)
+	getScriptHashesHistory(scriptHashes []string) (map[string][]txInfo, error)
 	getTx(txid string) (*transaction.Transaction, error)
 	getUtxos(outpoints []domain.Utxo) ([]domain.Utxo, error)
 	broadcastTx(txHex string) (string, error)

--- a/internal/infrastructure/blockchain-scanner/electrum/service.go
+++ b/internal/infrastructure/blockchain-scanner/electrum/service.go
@@ -205,7 +205,9 @@ func (s *service) setAccountChannels(
 
 func (s *service) listenToAccountChannel(chReports chan accountReport) {
 	for report := range chReports {
-		history, err := s.client.getScriptHashHistory(report.scriptHash)
+		history, err := s.client.getScriptHashesHistory(
+			[]string{report.scriptHash},
+		)
 		if err != nil {
 			s.warn(
 				err, "failed to get history for script hash %s", report.scriptHash,
@@ -213,7 +215,9 @@ func (s *service) listenToAccountChannel(chReports chan accountReport) {
 			continue
 		}
 
-		s.db.updateAccountTxHistory(report.account, report.scriptHash, history)
+		s.db.updateAccountTxHistory(
+			report.account, report.scriptHash, history[report.scriptHash],
+		)
 	}
 }
 

--- a/internal/infrastructure/blockchain-scanner/electrum/ws_client.go
+++ b/internal/infrastructure/blockchain-scanner/electrum/ws_client.go
@@ -20,15 +20,12 @@ import (
 )
 
 type wsClient struct {
-	conn      *websocket.Conn
-	nextId    uint64
-	chHandler *chHandler
-	chainTip  blockInfo
-
-	isSending    bool
-	reportQueue  []accountReport
-	chSendStatus chan bool
-	chQuit       chan struct{}
+	conn           *websocket.Conn
+	nextId         uint64
+	chHandler      *chHandler
+	chainTip       blockInfo
+	reportHandlers map[string]*reportHandler
+	chQuit         chan struct{}
 
 	tipLock  *sync.RWMutex
 	sendLock *sync.RWMutex
@@ -53,19 +50,17 @@ func newWSClient(addr string) (electrumClient, error) {
 	}
 
 	svc := &wsClient{
-		conn:         conn,
-		nextId:       0,
-		chHandler:    newChHandler(),
-		reportQueue:  make([]accountReport, 0),
-		chSendStatus: make(chan bool),
-		chQuit:       make(chan struct{}),
-		tipLock:      &sync.RWMutex{},
-		sendLock:     &sync.RWMutex{},
-		log:          logFn,
-		warn:         warnFn,
+		conn:           conn,
+		nextId:         0,
+		chHandler:      newChHandler(),
+		reportHandlers: make(map[string]*reportHandler),
+		chQuit:         make(chan struct{}),
+		tipLock:        &sync.RWMutex{},
+		sendLock:       &sync.RWMutex{},
+		log:            logFn,
+		warn:           warnFn,
 	}
 
-	go svc.listenSendStatus()
 	go svc.keepAliveConnection()
 
 	return svc, nil
@@ -110,12 +105,7 @@ func (c *wsClient) listen() {
 					scriptHash := resp.Params.([]interface{})[0].(string)
 					account := c.chHandler.getAccountByScriptHash(scriptHash)
 					report := accountReport{account, scriptHash}
-					if c.isSending {
-						c.reportQueue = append(c.reportQueue, report)
-					} else {
-						chReports := c.chHandler.getChReportsForAccount(account)
-						go func() { chReports <- report }()
-					}
+					c.reportHandlers[account].sendReport(report)
 					continue
 				case "blockchain.headers.subscribe":
 					buf, _ := json.Marshal(resp.Params.([]interface{})[0])
@@ -151,7 +141,6 @@ func (c *wsClient) keepAliveConnection() {
 func (c *wsClient) close() {
 	c.conn.Close()
 	c.chHandler.clear()
-	close(c.chSendStatus)
 	c.chQuit <- struct{}{}
 	close(c.chQuit)
 }
@@ -173,35 +162,46 @@ func (c *wsClient) subscribeForBlocks() {
 func (c *wsClient) subscribeForAccount(
 	accountName string, addresses []domain.AddressInfo,
 ) (chan accountReport, map[string][]txInfo) {
-	history := make(map[string][]txInfo)
-	c.setSendingStatus(true)
-	for _, info := range addresses {
-		scriptHash := calcScriptHash(info.Script)
-		if err := c.subscribeForScript(accountName, scriptHash); err != nil {
-			c.warn(
-				err, "failed to subscribe for script %s of account %s",
-				info.Script, accountName,
-			)
-			continue
-		}
+	if c.chHandler.getChReportsForAccount(accountName) == nil {
+		c.chHandler.addChReportForAccount(accountName)
+	}
 
+	chReports := c.chHandler.getChReportsForAccount(accountName)
+	if _, ok := c.reportHandlers[accountName]; !ok {
+		c.reportHandlers[accountName] = &reportHandler{
+			locker:      &sync.Mutex{},
+			chReports:   chReports,
+			reportQueue: make([]accountReport, 0),
+		}
+	}
+
+	scriptHashes := make([]string, 0, len(addresses))
+	c.reportHandlers[accountName].lock()
+	defer c.reportHandlers[accountName].unlock()
+
+	for _, info := range addresses {
+		scriptHashes = append(scriptHashes, calcScriptHash(info.Script))
 		c.log(
 			"start watching address %s for account %s",
 			info.DerivationPath, accountName,
 		)
-
-		addrHistory, err := c.getScriptHashHistory(scriptHash)
-		if err != nil {
-			continue
-		}
-		history[scriptHash] = addrHistory
 	}
-	c.setSendingStatus(false)
 
-	if c.chHandler.getChReportsForAccount(accountName) == nil {
-		c.chHandler.addChReportForAccount(accountName)
+	if err := c.subscribeForScripts(accountName, scriptHashes); err != nil {
+		c.warn(
+			err, "failed to subscribe for scripts of account %s", accountName,
+		)
 	}
-	return c.chHandler.getChReportsForAccount(accountName), history
+
+	history, err := c.getScriptHashesHistory(scriptHashes)
+	if err != nil {
+		c.warn(
+			err, "failed to get get tx history for watched addresses of account %s",
+			accountName,
+		)
+	}
+
+	return chReports, history
 }
 
 func (c *wsClient) unsubscribeForAccount(accountName string) {
@@ -212,19 +212,34 @@ func (c *wsClient) unsubscribeForAccount(accountName string) {
 	c.chHandler.clearAccount(accountName)
 }
 
-func (c *wsClient) getScriptHashHistory(scriptHash string) ([]txInfo, error) {
-	resp, err := c.request("blockchain.scripthash.get_history", scriptHash)
+func (c *wsClient) getScriptHashesHistory(scriptHashes []string) (map[string][]txInfo, error) {
+	reqs := make([]request, 0, len(scriptHashes))
+	scriptHashById := make(map[uint64]string)
+	for _, scriptHash := range scriptHashes {
+		req := c.newJSONRequest("blockchain.scripthash.get_history", scriptHash)
+		reqs = append(reqs, req)
+		scriptHashById[req.Id] = scriptHash
+	}
+	responses, err := c.batchRequests(reqs)
 	if err != nil {
 		return nil, err
 	}
-	if err := resp.error(); err != nil {
-		return nil, err
+
+	allHistory := make(map[string][]txInfo)
+	for _, resp := range responses {
+		if err := resp.error(); err != nil {
+			continue
+		}
+
+		scriptHash := scriptHashById[resp.Id]
+		history := make([]txInfo, 0)
+		buf, _ := json.Marshal(resp.Result)
+		json.Unmarshal(buf, &history)
+
+		allHistory[scriptHash] = append(allHistory[scriptHash], history...)
 	}
 
-	buf, _ := json.Marshal(resp.Result)
-	history := make([]txInfo, 0)
-	json.Unmarshal(buf, &history)
-	return history, nil
+	return allHistory, nil
 }
 
 func (c *wsClient) getLatestBlock() ([]byte, uint32, error) {
@@ -300,15 +315,29 @@ func (c *wsClient) broadcastTx(txHex string) (string, error) {
 	return resp.Result.(string), nil
 }
 
-func (c *wsClient) subscribeForScript(accountName, scriptHash string) error {
-	resp, err := c.request("blockchain.scripthash.subscribe", scriptHash)
+func (c *wsClient) subscribeForScripts(
+	accountName string, scriptHashes []string,
+) error {
+	reqs := make([]request, 0, len(scriptHashes))
+	for _, scriptHash := range scriptHashes {
+		reqs = append(reqs, c.newJSONRequest(
+			"blockchain.scripthash.subscribe", scriptHash),
+		)
+	}
+
+	responses, err := c.batchRequests(reqs)
 	if err != nil {
 		return err
 	}
-	if err := resp.error(); err != nil {
-		return err
+	for _, resp := range responses {
+		if err := resp.error(); err != nil {
+			return err
+		}
 	}
-	c.chHandler.addAccountScriptHash(accountName, scriptHash)
+
+	for _, scriptHash := range scriptHashes {
+		c.chHandler.addAccountScriptHash(accountName, scriptHash)
+	}
 	return nil
 }
 
@@ -325,12 +354,12 @@ func (c *wsClient) subscribeForScript(accountName, scriptHash string) error {
 // }
 
 func (c *wsClient) request(method string, params ...interface{}) (*response, error) {
-	req := c.newRequest(method, params...)
+	req := c.newJSONRequest(method, params...)
 	if err := c.conn.WriteJSON(req); err != nil {
 		c.warn(err, "failed to send request for method %s", method)
 	}
 
-	c.chHandler.addRequest(req)
+	c.chHandler.addRequests([]request{req})
 	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
 	defer func() {
 		cancel()
@@ -345,7 +374,47 @@ func (c *wsClient) request(method string, params ...interface{}) (*response, err
 	}
 }
 
-func (c *wsClient) newRequest(method string, params ...interface{}) request {
+func (c *wsClient) batchRequests(reqs []request) ([]response, error) {
+	reqBytes := make([]byte, 0)
+	for _, req := range reqs {
+		buf, _ := json.Marshal(req)
+		reqBytes = append(reqBytes, append(buf, delim)...)
+	}
+
+	if err := c.conn.WriteMessage(websocket.TextMessage, reqBytes); err != nil {
+		return nil, err
+	}
+
+	c.chHandler.addRequests(reqs)
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer func() {
+		cancel()
+		for _, req := range reqs {
+			c.chHandler.clearRequest(uint32(req.Id))
+		}
+	}()
+
+	responses := make([]response, 0, len(reqs))
+	ws := &sync.WaitGroup{}
+	ws.Add(len(reqs))
+
+	for i := range reqs {
+		req := reqs[i]
+		go func(req request) {
+			select {
+			case resp := <-c.chHandler.getChReportsForReqId(uint32(req.Id)):
+				responses = append(responses, resp)
+			case <-ctx.Done():
+				c.warn(nil, "request timed out")
+			}
+			ws.Done()
+		}(req)
+	}
+	ws.Wait()
+	return responses, nil
+}
+
+func (c *wsClient) newJSONRequest(method string, params ...interface{}) request {
 	params = append([]interface{}{}, params...)
 	return request{atomic.AddUint64(&c.nextId, 1), method, params}
 }
@@ -355,26 +424,4 @@ func (c *wsClient) updateChainTip(tip blockInfo) {
 	defer c.tipLock.Unlock()
 
 	c.chainTip = tip
-}
-
-func (c *wsClient) setSendingStatus(val bool) {
-	c.sendLock.Lock()
-	defer c.sendLock.Unlock()
-
-	c.isSending = val
-	c.chSendStatus <- val
-}
-
-func (c *wsClient) listenSendStatus() {
-	for isSending := range c.chSendStatus {
-		if !isSending {
-			for _, report := range c.reportQueue {
-				chReports := c.chHandler.getChReportsForAccount(report.account)
-				go func(chReport chan accountReport, report accountReport) {
-					chReports <- report
-				}(chReports, report)
-			}
-			c.reportQueue = make([]accountReport, 0)
-		}
-	}
 }


### PR DESCRIPTION
Before this, the electrum scanner was always sending a single request and waiting for the related response even in case of multiple requests like subscribing for addresses.
The changes introduced here allow the scanner to batch requests and send them all together. This new feature is used for addresses subscription and for getting their tx history. It significantly improves the performance of the scanner in terms of time.