### PR TITLE
[Electrum BC scanner] Reconnect TCP client if connection drops

### DIFF
--- a/internal/infrastructure/blockchain-scanner/electrum/utils.go
+++ b/internal/infrastructure/blockchain-scanner/electrum/utils.go
@@ -2,7 +2,11 @@ package electrum_scanner
 
 import (
 	"crypto/sha256"
+	"crypto/tls"
 	"encoding/hex"
+	"fmt"
+	"net"
+	"strings"
 
 	"github.com/btcsuite/btcd/chaincfg/chainhash"
 )
@@ -12,4 +16,17 @@ func calcScriptHash(script string) string {
 	hashedBuf := sha256.Sum256(buf)
 	hash, _ := chainhash.NewHash(hashedBuf[:])
 	return hash.String()
+}
+
+func getConn(addr string) (net.Conn, error) {
+	split := strings.Split(addr, "://")
+	proto, url := split[0], split[1]
+	switch proto {
+	case "tcp":
+		return net.Dial(proto, url)
+	case "ssl":
+		return tls.Dial("tcp", url, nil)
+	default:
+		return nil, fmt.Errorf("invalid address: unknown prototocol")
+	}
 }


### PR DESCRIPTION
This makes electrum TCP client reconnect to electrum server if the connection drops. An error at any stage of the reconnection process causes the service to exit an error.

Please @tiero @sekulicd review this.