### PR TITLE
Add explicit asset/value to pset inputs if needed

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -19,7 +19,7 @@ require (
 	github.com/stretchr/testify v1.8.0
 	github.com/timshannon/badgerhold/v4 v4.0.2
 	github.com/vulpemventures/go-bip39 v1.0.2
-	github.com/vulpemventures/go-elements v0.4.1
+	github.com/vulpemventures/go-elements v0.4.5
 	github.com/vulpemventures/neutrino-elements v0.1.3
 	golang.org/x/crypto v0.0.0-20220829220503-c86fa9a7ed90
 	golang.org/x/net v0.0.0-20220722155237-a158d28d115b
@@ -30,6 +30,7 @@ require (
 require (
 	github.com/jackc/pgconn v1.12.1
 	github.com/jackc/pgx/v4 v4.16.1
+	github.com/tyler-smith/go-bip39 v1.1.0
 )
 
 require (
@@ -81,7 +82,6 @@ require (
 	github.com/spf13/pflag v1.0.5 // indirect
 	github.com/stretchr/objx v0.4.0 // indirect
 	github.com/subosito/gotenv v1.3.0 // indirect
-	github.com/tyler-smith/go-bip39 v1.1.0 // indirect
 	github.com/vulpemventures/fastsha256 v0.0.0-20160815193821-637e65642941 // indirect
 	github.com/vulpemventures/go-secp256k1-zkp v1.1.5 // indirect
 	go.opencensus.io v0.23.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1197,8 +1197,8 @@ github.com/vulpemventures/fastsha256 v0.0.0-20160815193821-637e65642941 h1:CTcw8
 github.com/vulpemventures/fastsha256 v0.0.0-20160815193821-637e65642941/go.mod h1:GXBJykxW2kUcktGdsgyay7uwwWvkljASfljNcT0mbh8=
 github.com/vulpemventures/go-bip39 v1.0.2 h1:+BgKOVo04okKf1wA4Fhv8ccvql+qFyzVUdVJKkb48r0=
 github.com/vulpemventures/go-bip39 v1.0.2/go.mod h1:mjFmuv9D6BtANI6iscMmbHhmBOwjMCFfny3mxHnuDrk=
-github.com/vulpemventures/go-elements v0.4.1 h1:o9w0dv7I6NSCRG2Vh2TihHz3ffOk9ZdQtwsoTDAryrQ=
-github.com/vulpemventures/go-elements v0.4.1/go.mod h1:S7wy2QnrC2ElCZOscYMU2PYnnXRmuBQYfLMQGMVBqMg=
+github.com/vulpemventures/go-elements v0.4.5 h1:NlD68xcou9eYDIZiGTo7xpFuJV0IzcF4VQeix9cSdFU=
+github.com/vulpemventures/go-elements v0.4.5/go.mod h1:S7wy2QnrC2ElCZOscYMU2PYnnXRmuBQYfLMQGMVBqMg=
 github.com/vulpemventures/go-secp256k1-zkp v1.1.5 h1:oG1kO8ibVQ1wOvYcnFyuI+2YqnEZluXdRwkOPJlHBQM=
 github.com/vulpemventures/go-secp256k1-zkp v1.1.5/go.mod h1:zo7CpgkuPgoe7fAV+inyxsI9IhGmcoFgyD8nqZaPSOM=
 github.com/vulpemventures/neutrino-elements v0.1.3 h1:rzg6G1oL2fWodOZ716SOs71JuqttPCjjmig7TrlHrxM=

--- a/pkg/wallet/blind.go
+++ b/pkg/wallet/blind.go
@@ -95,7 +95,7 @@ func BlindPsetWithOwnedInputs(
 		return "", err
 	}
 	outBlindArgs, err := blindingGenerator.BlindOutputs(
-		ptx, outputIndexesToBlind, nil,
+		ptx, outputIndexesToBlind,
 	)
 	if err != nil {
 		return "", err
@@ -205,7 +205,7 @@ func BlindPsetWithMasterKey(
 	)
 
 	outBlindArgs, err := blindingGenerator.BlindOutputs(
-		ptx, outputIndexesToBlind, nil,
+		ptx, outputIndexesToBlind,
 	)
 	if err != nil {
 		return "", err


### PR DESCRIPTION
This updates go-elements dep to latest version `v0.4.5` that includes new methods for psetv2 updater `AddInExplictAsset` and `AddInExplictValue`, used here when creating/updating a partial transaction in case the input is confidential.

Please @sekulicd review this.