### PR TITLE
Fix peristance of tx notifications

### DIFF
--- a/internal/core/application/account_service.go
+++ b/internal/core/application/account_service.go
@@ -3,6 +3,7 @@ package application
 import (
 	"context"
 	"fmt"
+	"strings"
 	"time"
 
 	log "github.com/sirupsen/logrus"
@@ -31,6 +32,7 @@ import (
 type AccountService struct {
 	repoManager ports.RepoManager
 	bcScanner   ports.BlockchainScanner
+	txQueue     *transactionQueue
 
 	log  func(format string, a ...interface{})
 	warn func(err error, format string, a ...interface{})
@@ -39,6 +41,7 @@ type AccountService struct {
 func NewAccountService(
 	repoManager ports.RepoManager, bcScanner ports.BlockchainScanner,
 ) *AccountService {
+	txQueue := newTransactionQueue()
 	logFn := func(format string, a ...interface{}) {
 		format = fmt.Sprintf("account service: %s", format)
 		log.Debugf(format, a...)
@@ -48,7 +51,7 @@ func NewAccountService(
 		log.WithError(err).Warnf(format, a...)
 	}
 
-	svc := &AccountService{repoManager, bcScanner, logFn, warnFn}
+	svc := &AccountService{repoManager, bcScanner, txQueue, logFn, warnFn}
 	svc.registerHandlerForWalletEvents()
 	return svc
 }
@@ -329,50 +332,55 @@ func (as *AccountService) listenToTxChannel(
 ) {
 	as.log("start listening to tx channel for account %s", accountName)
 
+	// Every tx received from the blockchain scanner is pushed to a queue that is
+	// emptied 1 second after the first elem is added. All the queued txs are
+	// then persisted in the repository. This because it can happen to receive
+	// here the same tx on 2 different channels in case the user moves
+	// funds from one account to another.
+	// In such cases, the queue takes care of updating a tx if it's already
+	// queued, instead of doing this operation against the repo (can be slower).
+	for tx := range chTxs {
+		if as.txQueue.len() <= 0 {
+			go func() {
+				time.Sleep(time.Second)
+				as.storeQueuedTransactions()
+			}()
+		}
+		as.txQueue.pushBack(tx)
+	}
+}
+
+func (as *AccountService) storeQueuedTransactions() {
+	txs := as.txQueue.pop()
 	ctx := context.Background()
 	txRepo := as.repoManager.TransactionRepository()
-	for tx := range chTxs {
-		time.Sleep(time.Millisecond)
-
-		as.log("received new tx %s from channel", tx.TxID)
-
+	for _, tx := range txs {
 		gotTx, _ := txRepo.GetTransaction(ctx, tx.TxID)
+		accounts := strings.Join(tx.GetAccounts(), ", ")
 		if gotTx == nil {
+			as.log("received new tx %s from channel", tx.TxID)
+
 			if _, err := txRepo.AddTransaction(ctx, tx); err != nil {
-				as.warn(
-					err, "error while adding new transaction %s for account %s",
-					tx.TxID, accountName,
-				)
+				as.warn(err, "error while adding new transaction %s", tx.TxID)
 				continue
 			}
-			as.log("added new transaction %s for account %s", tx.TxID, accountName)
+			as.log("added new transaction %s for account(s) %s", tx.TxID, accounts)
 			continue
 		}
+
 		if !gotTx.IsConfirmed() && tx.IsConfirmed() {
+			as.log("received confirmed tx %s from channel", tx.TxID)
+
 			if _, err := txRepo.ConfirmTransaction(
 				ctx, tx.TxID, tx.BlockHash, tx.BlockHeight,
 			); err != nil {
 				as.warn(
-					err, "error while confirming transaction %s for account %s",
-					tx.TxID, accountName,
+					err, "error while confirming transaction %s for account(s) %s",
+					tx.TxID, accounts,
 				)
-			}
-			as.log("confirmed transaction %s for account %s", tx.TxID, accountName)
-		}
-
-		if !gotTx.HasAccounts(tx) {
-			if err := txRepo.UpdateTransaction(
-				ctx, tx.TxID, func(t *domain.Transaction) (*domain.Transaction, error) {
-					for _, account := range tx.GetAccounts() {
-						t.AddAccount(account)
-					}
-					return t, nil
-				},
-			); err != nil {
-				as.warn(err, "error while updating accounts to transaction %s", tx.TxID)
 				continue
 			}
-			as.log("updated accounts for transaction %s", tx.TxID)
+			as.log("confirmed transaction %s for account(s) %s", tx.TxID, accounts)
 		}
 	}
 }

--- a/internal/core/domain/transaction_repository.go
+++ b/internal/core/domain/transaction_repository.go
@@ -33,11 +33,11 @@ type TransactionEvent struct {
 type TransactionRepository interface {
 	// AddTransaction adds the provided transaction to the repository by
 	// preventing duplicates.
-	// Generates a TransactionAdded event if successfull.
+	// Generates a TransactionAdded event if successful.
 	AddTransaction(ctx context.Context, tx *Transaction) (bool, error)
 	// ConfirmTransaction adds the given blockhash and block height to the
 	// Transaction identified by the given txid.
-	// Generates a TransactionConfirmed event if successfull.
+	// Generates a TransactionConfirmed event if successful.
 	ConfirmTransaction(
 		ctx context.Context, txid, blockHash string, blockheight uint64,
 	) (bool, error)

--- a/internal/interfaces/grpc/handler/util.go
+++ b/internal/interfaces/grpc/handler/util.go
@@ -211,6 +211,8 @@ func parseTxEventType(eventType domain.TransactionEventType) pb.TxEventType {
 		return pb.TxEventType_TX_EVENT_TYPE_BROADCASTED
 	case domain.TransactionConfirmed:
 		return pb.TxEventType_TX_EVENT_TYPE_CONFIRMED
+	case domain.TransactionUnconfirmed:
+		return pb.TxEventType_TX_EVENT_TYPE_UNCONFIRMED
 	default:
 		return pb.TxEventType_TX_EVENT_TYPE_UNSPECIFIED
 	}


### PR DESCRIPTION
This fixes how the app service persists the transaction received from the blockchain scanner by introducing a queue where all the received txs are pushed before being stored in the repository.

The reason is that for "multi account" txs, ie. those moving funds from one account to another, it happens that the same tx is sent over 2 different account channels barely at the same time and it's evident that it becomes problematic to persist the tx directly because of conflicts.

To prevent this, as mentioned, all txs received from the blockchain scanner are pushed to a queue that is emptied after 1 second the very first elem is added. This gives enough time to eventually update the account names of an already queued tx and allows the app svc to just add or confirm a tx in the repo without any extra operation that would slow even more this background process.
