### PR TITLE
fix: Handle skipping signature in SignPset if the input is not complete

### DIFF
--- a/pkg/wallet/single-sig/sign.go
+++ b/pkg/wallet/single-sig/sign.go
@@ -135,6 +135,12 @@ func (w *Wallet) SignPset(args SignPsetArgs) (string, error) {
 
 	ptx, _ := psetv2.NewPsetFromBase64(args.PsetBase64)
 	for i, in := range ptx.Inputs {
+		// GetUtxo() is unsafe if the partial transaction is not complete
+		// It handles gracefully by skipping the signature
+		// TODO: consider lifting the information to the way up
+		if in.WitnessUtxo == nil && in.NonWitnessUtxo == nil {
+			continue
+		}
 		path, ok := args.DerivationPathMap[hex.EncodeToString(in.GetUtxo().Script)]
 		if ok {
 			err := w.signInput(ptx, i, path, args.sighashType())


### PR DESCRIPTION
This prevents partial transactions not complete to crash the daemon, we simply skip signing that input if not ready

It fixes #63 