### PR TITLE
Fix transfer & Update deps & Hotfix bug

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,6 +40,7 @@ run: clean
 	export OCEAN_STATS_INTERVAL=120; \
 	export OCEAN_ELECTRUM_URL=tcp://localhost:50001; \
 	export OCEAN_UTXO_EXPIRY_DURATION_IN_SECONDS=60; \
+	export OCEAN_DB_TYPE=badger; \
 	go run ./cmd/oceand
 
 test: fmt

--- a/cmd/oceand/main.go
+++ b/cmd/oceand/main.go
@@ -49,6 +49,7 @@ var (
 	dbPort             = config.GetInt(config.DbPortKey)
 	dbName             = config.GetString(config.DbNameKey)
 	migrationSourceURL = config.GetString(config.DbMigrationPath)
+	dustAmount         = uint64(config.GetInt(config.DustAmountKey))
 )
 
 func main() {
@@ -87,6 +88,7 @@ func main() {
 		RootPath:                rootPath,
 		Network:                 network,
 		UtxoExpiryDuration:      utxoExpiryDuration * time.Second,
+		DustAmount:              dustAmount,
 		RepoManagerType:         dbType,
 		BlockchainScannerType:   bcScannerType,
 		RepoManagerConfig:       repoManagerConfig,

--- a/go.mod
+++ b/go.mod
@@ -19,7 +19,7 @@ require (
 	github.com/stretchr/testify v1.8.1
 	github.com/timshannon/badgerhold/v4 v4.0.2
 	github.com/vulpemventures/go-bip39 v1.0.2
-	github.com/vulpemventures/go-elements v0.4.5
+	github.com/vulpemventures/go-elements v0.5.1
 	github.com/vulpemventures/neutrino-elements v0.1.3
 	golang.org/x/crypto v0.1.0
 	golang.org/x/net v0.7.0
@@ -83,7 +83,7 @@ require (
 	github.com/stretchr/objx v0.5.0 // indirect
 	github.com/subosito/gotenv v1.3.0 // indirect
 	github.com/vulpemventures/fastsha256 v0.0.0-20160815193821-637e65642941 // indirect
-	github.com/vulpemventures/go-secp256k1-zkp v1.1.5 // indirect
+	github.com/vulpemventures/go-secp256k1-zkp v1.1.6 // indirect
 	go.opencensus.io v0.24.0 // indirect
 	go.uber.org/atomic v1.10.0 // indirect
 	golang.org/x/sys v0.5.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1203,8 +1203,11 @@ github.com/vulpemventures/go-bip39 v1.0.2 h1:+BgKOVo04okKf1wA4Fhv8ccvql+qFyzVUdV
 github.com/vulpemventures/go-bip39 v1.0.2/go.mod h1:mjFmuv9D6BtANI6iscMmbHhmBOwjMCFfny3mxHnuDrk=
 github.com/vulpemventures/go-elements v0.4.5 h1:NlD68xcou9eYDIZiGTo7xpFuJV0IzcF4VQeix9cSdFU=
 github.com/vulpemventures/go-elements v0.4.5/go.mod h1:S7wy2QnrC2ElCZOscYMU2PYnnXRmuBQYfLMQGMVBqMg=
+github.com/vulpemventures/go-elements v0.5.1 h1:F83n7dScOnAnpyH9VgWLdC68Qcva+2EWVzzNuW2UKak=
+github.com/vulpemventures/go-elements v0.5.1/go.mod h1:aBGuWXHaiAIUIcwqCdtEh2iQ3kJjKwHU9ywvhlcRSeU=
 github.com/vulpemventures/go-secp256k1-zkp v1.1.5 h1:oG1kO8ibVQ1wOvYcnFyuI+2YqnEZluXdRwkOPJlHBQM=
 github.com/vulpemventures/go-secp256k1-zkp v1.1.5/go.mod h1:zo7CpgkuPgoe7fAV+inyxsI9IhGmcoFgyD8nqZaPSOM=
+github.com/vulpemventures/go-secp256k1-zkp v1.1.6/go.mod h1:zo7CpgkuPgoe7fAV+inyxsI9IhGmcoFgyD8nqZaPSOM=
 github.com/vulpemventures/neutrino-elements v0.1.3 h1:rzg6G1oL2fWodOZ716SOs71JuqttPCjjmig7TrlHrxM=
 github.com/vulpemventures/neutrino-elements v0.1.3/go.mod h1:pSl1A515bPEw9PxnyVwxyTpXH5GZNMMBacOCs7Ioyds=
 github.com/willf/bitset v1.1.11-0.20200630133818-d5bec3311243/go.mod h1:RjeCKbqT1RxIR/KWY6phxZiaY1IyutSBfGjNPySAYV4=

--- a/internal/app-config/config.go
+++ b/internal/app-config/config.go
@@ -38,6 +38,7 @@ type AppConfig struct {
 	RootPath           string
 	Network            *network.Network
 	UtxoExpiryDuration time.Duration
+	DustAmount         uint64
 
 	RepoManagerType         string
 	BlockchainScannerType   string
@@ -58,6 +59,9 @@ func (c *AppConfig) Validate() error {
 	}
 	if c.UtxoExpiryDuration == 0 {
 		return fmt.Errorf("missing utxo expiry duration")
+	}
+	if c.DustAmount == 0 {
+		return fmt.Errorf("missing dust amount threshold")
 	}
 	if len(c.RepoManagerType) == 0 {
 		return fmt.Errorf("missing repo manager type")
@@ -252,7 +256,7 @@ func (c *AppConfig) transactionService() *application.TransactionService {
 	rm, _ := c.repoManager()
 	bcs, _ := c.bcScanner()
 	c.txSvc = application.NewTransactionService(
-		rm, bcs, c.Network, c.UtxoExpiryDuration,
+		rm, bcs, c.Network, c.UtxoExpiryDuration, c.DustAmount,
 	)
 	return c.txSvc
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -77,6 +77,8 @@ const (
 	DbNameKey = "DB_NAME"
 	// DbMigrationPath is the path to migration files
 	DbMigrationPath = "DB_MIGRATION_PATH"
+	// DustAmountKey is the key to customize the dust amount threshold
+	DustAmountKey = "DUST_AMOUNT"
 
 	// DbLocation is the folder inside the datadir containing db files.
 	DbLocation = "db"
@@ -105,6 +107,7 @@ var (
 	defaultUtxoExpiryDuration = 360 // 6 minutes (3 blocks)
 	defaultEsploraUrl         = "https://blockstream.info/liquid/api"
 	defaultElectrumUrl        = "ssl://blockstream.info:995"
+	defaultDustAmount         = uint64(450)
 
 	supportedNetworks = map[string]*network.Network{
 		network.Liquid.Name:  &network.Liquid,
@@ -152,6 +155,7 @@ func init() {
 	vip.SetDefault(DbNameKey, "oceand-db")
 	vip.SetDefault(DbMigrationPath, "file://internal/infrastructure/storage/db/postgres/migration")
 	vip.SetDefault(ElectrumUrlKey, defaultElectrumUrl)
+	vip.SetDefault(DustAmountKey, defaultDustAmount)
 
 	if err := validate(); err != nil {
 		log.Fatalf("invalid config: %s", err)

--- a/internal/core/application/transaction_service_test.go
+++ b/internal/core/application/transaction_service_test.go
@@ -28,6 +28,7 @@ var (
 		},
 	}
 	utxoExpiryDuration = 2 * time.Minute
+	dustAmount         = uint64(450)
 )
 
 func TestTransactionService(t *testing.T) {
@@ -46,7 +47,7 @@ func testExternalTransaction(t *testing.T) {
 		require.NotNil(t, repoManager)
 
 		svc := application.NewTransactionService(
-			repoManager, mockedBcScanner, regtest, utxoExpiryDuration,
+			repoManager, mockedBcScanner, regtest, utxoExpiryDuration, dustAmount,
 		)
 
 		selectedUtxos, change, expirationDate, err := svc.SelectUtxos(
@@ -127,7 +128,7 @@ func testInternalTransaction(t *testing.T) {
 		require.NotNil(t, repoManager)
 
 		svc := application.NewTransactionService(
-			repoManager, mockedBcScanner, regtest, utxoExpiryDuration,
+			repoManager, mockedBcScanner, regtest, utxoExpiryDuration, dustAmount,
 		)
 
 		txid, err := svc.Transfer(ctx, accountName, outputs, 0)

--- a/pkg/wallet/single-sig/sign.go
+++ b/pkg/wallet/single-sig/sign.go
@@ -135,7 +135,11 @@ func (w *Wallet) SignPset(args SignPsetArgs) (string, error) {
 
 	ptx, _ := psetv2.NewPsetFromBase64(args.PsetBase64)
 	for i, in := range ptx.Inputs {
-		path, ok := args.DerivationPathMap[hex.EncodeToString(in.GetUtxo().Script)]
+		prevout := in.GetUtxo()
+		if prevout == nil {
+			continue
+		}
+		path, ok := args.DerivationPathMap[hex.EncodeToString(prevout.Script)]
 		if ok {
 			err := w.signInput(ptx, i, path, args.sighashType())
 			if err != nil {


### PR DESCRIPTION
This fixes the implementation of the `Transfer` rpc to:
- not produce lbtc dust outputs, preventing the tx to be accepted in mempool
- fix the creation of the tx in case the user specifies many receivers

This also updates go-elements to v0.5.1 and includes #64.

Please @tiero review.