### PR TITLE
Add validation checks & fix send all logic in Transfer rpc

### DIFF
--- a/internal/core/application/transaction_service.go
+++ b/internal/core/application/transaction_service.go
@@ -357,6 +357,13 @@ func (ts *TransactionService) Transfer(
 	if len(balance) <= 0 {
 		return "", fmt.Errorf("account %s has 0 balance", accountName)
 	}
+	for asset, amount := range outputs.totalAmountByAsset() {
+		if (balance[asset].Confirmed + balance[asset].Unconfirmed) < amount {
+			return "", fmt.Errorf(
+				"not enough funds to cover amount %d of asset %s", amount, asset,
+			)
+		}
+	}
 
 	utxos, err := utxoRepo.GetSpendableUtxosForAccount(
 		ctx, account.Namespace,

--- a/internal/infrastructure/coin-selector/smallest-subset/selector.go
+++ b/internal/infrastructure/coin-selector/smallest-subset/selector.go
@@ -27,7 +27,7 @@ func (s *selector) SelectUtxos(
 	})
 
 	targetUtxos := make([]*domain.Utxo, 0)
-	totalAmount := uint64(0)
+	balance := uint64(0)
 	for i := range utxos {
 		utxo := utxos[i]
 		if utxo.IsConfidential() && !utxo.IsRevealed() {
@@ -35,7 +35,12 @@ func (s *selector) SelectUtxos(
 		}
 		if utxo.Asset == targetAsset {
 			targetUtxos = append(targetUtxos, utxo)
+			balance += utxo.Value
 		}
+	}
+
+	if targetAmount == balance {
+		return targetUtxos, 0, nil
 	}
 
 	indexes := selectUtxos(targetAmount, targetUtxos)
@@ -44,6 +49,7 @@ func (s *selector) SelectUtxos(
 	}
 
 	selectedUtxos := make([]*domain.Utxo, 0)
+	totalAmount := uint64(0)
 	for _, v := range indexes {
 		totalAmount += targetUtxos[v].Value
 		selectedUtxos = append(selectedUtxos, targetUtxos[v])


### PR DESCRIPTION
This adds a missing validation check in Transfer rpc that returns an error some target amount is bigger than the wallet balance for a given target asset.

This adds also a check in the coin selector that returns all utxos of an asset without checking all possible combinations if the   target amount is equal to the wallet balance.