### PR TITLE
Add block timestamp info to stored txs

### DIFF
--- a/internal/core/application/account_service.go
+++ b/internal/core/application/account_service.go
@@ -372,7 +372,7 @@ func (as *AccountService) storeQueuedTransactions() {
 			as.log("received confirmed tx %s from channel", tx.TxID)
 
 			if _, err := txRepo.ConfirmTransaction(
-				ctx, tx.TxID, tx.BlockHash, tx.BlockHeight,
+				ctx, tx.TxID, tx.BlockHash, tx.BlockHeight, tx.BlockTime,
 			); err != nil {
 				as.warn(
 					err, "error while confirming transaction %s for account(s) %s",

--- a/internal/core/application/notification_service_test.go
+++ b/internal/core/application/notification_service_test.go
@@ -82,10 +82,11 @@ func testGetTxChannel(t *testing.T) {
 
 	time.Sleep(time.Second)
 
-	blockHash := randomHex(32)
-	blockHeight := uint64(randomIntInRange(1, 300))
+	blockhash := randomHex(32)
+	blockheight := uint64(randomIntInRange(1, 300))
+	blocktime := time.Now().Unix()
 	repoManager.TransactionRepository().ConfirmTransaction(
-		ctx, txid, blockHash, blockHeight,
+		ctx, txid, blockhash, blockheight, blocktime,
 	)
 
 	repoManager.TransactionRepository().UpdateTransaction(

--- a/internal/core/domain/transaction.go
+++ b/internal/core/domain/transaction.go
@@ -8,6 +8,7 @@ type Transaction struct {
 	TxHex       string
 	BlockHash   string
 	BlockHeight uint64
+	BlockTime   int64
 	Accounts    map[string]struct{}
 }
 
@@ -17,13 +18,16 @@ func (t *Transaction) IsConfirmed() bool {
 }
 
 // Confirm marks the tx as confirmed.
-func (t *Transaction) Confirm(blockHash string, blockHeight uint64) {
+func (t *Transaction) Confirm(
+	blockHash string, blockHeight uint64, blockTime int64,
+) {
 	if t.IsConfirmed() {
 		return
 	}
 
 	t.BlockHash = blockHash
 	t.BlockHeight = blockHeight
+	t.BlockTime = blockTime
 }
 
 // AddAccount adds the given account to the map of those involved in the tx.

--- a/internal/core/domain/transaction_repository.go
+++ b/internal/core/domain/transaction_repository.go
@@ -39,7 +39,8 @@ type TransactionRepository interface {
 	// Transaction identified by the given txid.
 	// Generates a TransactionConfirmed event if successful.
 	ConfirmTransaction(
-		ctx context.Context, txid, blockHash string, blockheight uint64,
+		ctx context.Context,
+		txid, blockHash string, blockheight uint64, blocktime int64,
 	) (bool, error)
 	// GetTransaction returns the Transaction identified by the given txid.
 	GetTransaction(ctx context.Context, txid string) (*Transaction, error)

--- a/internal/core/domain/transaction_test.go
+++ b/internal/core/domain/transaction_test.go
@@ -2,6 +2,7 @@ package domain_test
 
 import (
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 	"github.com/vulpemventures/ocean/internal/core/domain"
@@ -11,7 +12,7 @@ func TestConfirmTransaction(t *testing.T) {
 	tx := &domain.Transaction{}
 	require.False(t, tx.IsConfirmed())
 
-	tx.Confirm("fa84eb6806daf1b3c495ed30554d80573a39335b2993b66b3cc1afaa53816e47", 1728312)
+	tx.Confirm("fa84eb6806daf1b3c495ed30554d80573a39335b2993b66b3cc1afaa53816e47", 1728312, time.Now().Unix())
 	require.True(t, tx.IsConfirmed())
 }
 

--- a/internal/infrastructure/blockchain-scanner/electrum/service.go
+++ b/internal/infrastructure/blockchain-scanner/electrum/service.go
@@ -555,19 +555,22 @@ func (s *service) dbEventHandler(event dbEvent) {
 	chTx := s.getTxChannelByAccount(event.account)
 	txHex, _ := tx.ToHex()
 
-	var hash string
-	var blockHeight uint64
+	var blockhash string
+	var blockheight uint64
+	var blocktime int64
 	if block != nil {
-		hash = block.hash().String()
-		blockHeight = uint64(event.tx.Height)
+		blockhash = block.hash().String()
+		blockheight = uint64(event.tx.Height)
+		blocktime = block.timestamp()
 	}
 
 	go func() {
 		chTx <- &domain.Transaction{
 			TxID:        event.tx.Txid,
 			TxHex:       txHex,
-			BlockHash:   hash,
-			BlockHeight: blockHeight,
+			BlockHash:   blockhash,
+			BlockHeight: blockheight,
+			BlockTime:   blocktime,
 			Accounts:    map[string]struct{}{event.account: {}},
 		}
 	}()

--- a/internal/infrastructure/storage/db/badger/transaction_repository.go
+++ b/internal/infrastructure/storage/db/badger/transaction_repository.go
@@ -55,7 +55,8 @@ func (r *transactionRepository) AddTransaction(
 }
 
 func (r *transactionRepository) ConfirmTransaction(
-	ctx context.Context, txid, blockHash string, blockheight uint64,
+	ctx context.Context,
+	txid, blockHash string, blockheight uint64, blocktime int64,
 ) (bool, error) {
 	tx, err := r.getTx(ctx, txid)
 	if err != nil {
@@ -66,7 +67,7 @@ func (r *transactionRepository) ConfirmTransaction(
 		return false, nil
 	}
 
-	tx.Confirm(blockHash, blockheight)
+	tx.Confirm(blockHash, blockheight, blocktime)
 
 	if err := r.updateTx(ctx, *tx); err != nil {
 		return false, err

--- a/internal/infrastructure/storage/db/inmemory/transaction_repository.go
+++ b/internal/infrastructure/storage/db/inmemory/transaction_repository.go
@@ -46,12 +46,13 @@ func (r *txRepository) AddTransaction(
 }
 
 func (r *txRepository) ConfirmTransaction(
-	ctx context.Context, txid, blockHash string, blockheight uint64,
+	ctx context.Context,
+	txid, blockHash string, blockheight uint64, blocktime int64,
 ) (bool, error) {
 	r.store.lock.Lock()
 	defer r.store.lock.Unlock()
 
-	return r.confirmTx(ctx, txid, blockHash, blockheight)
+	return r.confirmTx(ctx, txid, blockHash, blockheight, blocktime)
 }
 
 func (r *txRepository) GetTransaction(
@@ -106,7 +107,8 @@ func (r *txRepository) addTx(
 }
 
 func (r *txRepository) confirmTx(
-	ctx context.Context, txid string, blockHash string, blockHeight uint64,
+	ctx context.Context,
+	txid string, blockHash string, blockHeight uint64, blocktime int64,
 ) (bool, error) {
 	tx, err := r.getTx(ctx, txid)
 	if err != nil {
@@ -117,7 +119,7 @@ func (r *txRepository) confirmTx(
 		return false, nil
 	}
 
-	tx.Confirm(blockHash, blockHeight)
+	tx.Confirm(blockHash, blockHeight, blocktime)
 
 	r.store.txs[txid] = tx
 

--- a/internal/infrastructure/storage/db/postgres/migration/20240131150155_add_blocktime_field.down.sql
+++ b/internal/infrastructure/storage/db/postgres/migration/20240131150155_add_blocktime_field.down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE transaction DROP COLUMN block_time;

--- a/internal/infrastructure/storage/db/postgres/migration/20240131150155_add_blocktime_field.up.sql
+++ b/internal/infrastructure/storage/db/postgres/migration/20240131150155_add_blocktime_field.up.sql
@@ -1,0 +1,1 @@
+ALTER TABLE transaction ADD COLUMN block_time BIGINT;

--- a/internal/infrastructure/storage/db/postgres/sqlc/queries/models.go
+++ b/internal/infrastructure/storage/db/postgres/sqlc/queries/models.go
@@ -37,6 +37,7 @@ type Transaction struct {
 	TxHex       string
 	BlockHash   string
 	BlockHeight int32
+	BlockTime   sql.NullInt64
 }
 
 type TxInputAccount struct {

--- a/internal/infrastructure/storage/db/postgres/sqlc/queries/query.sql.go
+++ b/internal/infrastructure/storage/db/postgres/sqlc/queries/query.sql.go
@@ -193,7 +193,7 @@ func (q *Queries) GetScript(ctx context.Context, account string) (ExternalScript
 }
 
 const getTransaction = `-- name: GetTransaction :many
-SELECT tx_id, tx_hex, block_hash, block_height, id, account_name, fk_tx_id FROM transaction t left join tx_input_account tia on t.tx_id = tia.fk_tx_id WHERE tx_id=$1
+SELECT tx_id, tx_hex, block_hash, block_height, block_time, id, account_name, fk_tx_id FROM transaction t left join tx_input_account tia on t.tx_id = tia.fk_tx_id WHERE tx_id=$1
 `
 
 type GetTransactionRow struct {
@@ -201,6 +201,7 @@ type GetTransactionRow struct {
 	TxHex       string
 	BlockHash   string
 	BlockHeight int32
+	BlockTime   sql.NullInt64
 	ID          sql.NullInt32
 	AccountName sql.NullString
 	FkTxID      sql.NullString
@@ -220,6 +221,7 @@ func (q *Queries) GetTransaction(ctx context.Context, txID string) ([]GetTransac
 			&i.TxHex,
 			&i.BlockHash,
 			&i.BlockHeight,
+			&i.BlockTime,
 			&i.ID,
 			&i.AccountName,
 			&i.FkTxID,
@@ -558,8 +560,8 @@ func (q *Queries) InsertScript(ctx context.Context, arg InsertScriptParams) erro
 }
 
 const insertTransaction = `-- name: InsertTransaction :one
-INSERT INTO transaction(tx_id,tx_hex,block_hash,block_height)
-VALUES($1,$2,$3,$4) RETURNING tx_id, tx_hex, block_hash, block_height
+INSERT INTO transaction(tx_id,tx_hex,block_hash,block_height,block_time)
+VALUES($1,$2,$3,$4,$5) RETURNING tx_id, tx_hex, block_hash, block_height, block_time
 `
 
 type InsertTransactionParams struct {
@@ -567,6 +569,7 @@ type InsertTransactionParams struct {
 	TxHex       string
 	BlockHash   string
 	BlockHeight int32
+	BlockTime   sql.NullInt64
 }
 
 // TRANSACTION
@@ -576,6 +579,7 @@ func (q *Queries) InsertTransaction(ctx context.Context, arg InsertTransactionPa
 		arg.TxHex,
 		arg.BlockHash,
 		arg.BlockHeight,
+		arg.BlockTime,
 	)
 	var i Transaction
 	err := row.Scan(
@@ -583,6 +587,7 @@ func (q *Queries) InsertTransaction(ctx context.Context, arg InsertTransactionPa
 		&i.TxHex,
 		&i.BlockHash,
 		&i.BlockHeight,
+		&i.BlockTime,
 	)
 	return i, err
 }
@@ -810,13 +815,14 @@ func (q *Queries) UpdateAccount(ctx context.Context, arg UpdateAccountParams) (A
 }
 
 const updateTransaction = `-- name: UpdateTransaction :one
-UPDATE transaction SET tx_hex=$1,block_hash=$2,block_height=$3 WHERE tx_id=$4 RETURNING tx_id, tx_hex, block_hash, block_height
+UPDATE transaction SET tx_hex=$1,block_hash=$2,block_height=$3,block_time=$4 WHERE tx_id=$5 RETURNING tx_id, tx_hex, block_hash, block_height, block_time
 `
 
 type UpdateTransactionParams struct {
 	TxHex       string
 	BlockHash   string
 	BlockHeight int32
+	BlockTime   sql.NullInt64
 	TxID        string
 }
 
@@ -825,6 +831,7 @@ func (q *Queries) UpdateTransaction(ctx context.Context, arg UpdateTransactionPa
 		arg.TxHex,
 		arg.BlockHash,
 		arg.BlockHeight,
+		arg.BlockTime,
 		arg.TxID,
 	)
 	var i Transaction
@@ -833,6 +840,7 @@ func (q *Queries) UpdateTransaction(ctx context.Context, arg UpdateTransactionPa
 		&i.TxHex,
 		&i.BlockHash,
 		&i.BlockHeight,
+		&i.BlockTime,
 	)
 	return i, err
 }

--- a/internal/infrastructure/storage/db/postgres/sqlc/query.sql
+++ b/internal/infrastructure/storage/db/postgres/sqlc/query.sql
@@ -65,15 +65,15 @@ SELECT * FROM utxo WHERE account_name=$1;
 
 /* TRANSACTION */
 -- name: InsertTransaction :one
-INSERT INTO transaction(tx_id,tx_hex,block_hash,block_height)
-VALUES($1,$2,$3,$4) RETURNING *;
+INSERT INTO transaction(tx_id,tx_hex,block_hash,block_height,block_time)
+VALUES($1,$2,$3,$4,$5) RETURNING *;
 
 -- name: InsertTransactionInputAccount :one
 INSERT INTO tx_input_account(account_name, fk_tx_id)
 VALUES($1,$2) RETURNING *;
 
 -- name: UpdateTransaction :one
-UPDATE transaction SET tx_hex=$1,block_hash=$2,block_height=$3 WHERE tx_id=$4 RETURNING *;
+UPDATE transaction SET tx_hex=$1,block_hash=$2,block_height=$3,block_time=$4 WHERE tx_id=$5 RETURNING *;
 
 -- name: DeleteTransactionInputAccounts :exec
 DELETE FROM tx_input_account WHERE fk_tx_id=$1;

--- a/internal/infrastructure/storage/db/test/transaction_repository_test.go
+++ b/internal/infrastructure/storage/db/test/transaction_repository_test.go
@@ -3,6 +3,7 @@ package db_test
 import (
 	"fmt"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 	"github.com/vulpemventures/ocean/internal/core/domain"
@@ -62,12 +63,13 @@ func testTransactionRepository(t *testing.T, repo domain.TransactionRepository) 
 	t.Run("confirm_transaction", func(t *testing.T) {
 		blockHash := randomHex(32)
 		blockHeight := uint64(randomIntInRange(100, 1000))
+		blocktime := time.Now().Unix()
 
-		done, err := repo.ConfirmTransaction(ctx, txid, blockHash, blockHeight)
+		done, err := repo.ConfirmTransaction(ctx, txid, blockHash, blockHeight, blocktime)
 		require.NoError(t, err)
 		require.True(t, done)
 
-		done, err = repo.ConfirmTransaction(ctx, txid, blockHash, blockHeight)
+		done, err = repo.ConfirmTransaction(ctx, txid, blockHash, blockHeight, blocktime)
 		require.NoError(t, err)
 		require.False(t, done)
 

--- a/internal/interfaces/grpc/handler/notification.go
+++ b/internal/interfaces/grpc/handler/notification.go
@@ -38,8 +38,9 @@ func (n notification) TransactionNotifications(
 			var blockDetails *pb.BlockDetails
 			if e.Transaction.IsConfirmed() {
 				blockDetails = &pb.BlockDetails{
-					Hash:   e.Transaction.BlockHash,
-					Height: e.Transaction.BlockHeight,
+					Hash:      e.Transaction.BlockHash,
+					Height:    e.Transaction.BlockHeight,
+					Timestamp: e.Transaction.BlockTime,
 				}
 			}
 			if err := stream.Send(&pb.TransactionNotificationsResponse{

--- a/internal/interfaces/grpc/handler/util.go
+++ b/internal/interfaces/grpc/handler/util.go
@@ -109,7 +109,7 @@ func parseBlockDetails(tx application.TransactionInfo) *pb.BlockDetails {
 	return &pb.BlockDetails{
 		Hash:      tx.BlockHash,
 		Height:    tx.BlockHeight,
-		Timestamp: int64(tx.BlockHeight),
+		Timestamp: tx.BlockTime,
 	}
 }
 


### PR DESCRIPTION
This adds support for storing and returning the block timestamp of a transaction for a watched output script, either it is derived from the wallet, or an external one provided by the user.

Closes #77 

@louisinger please review.