### PR TITLE
Panic recovery

### DIFF
--- a/internal/core/application/transaction_service.go
+++ b/internal/core/application/transaction_service.go
@@ -20,7 +20,7 @@ import (
 	"github.com/vulpemventures/go-elements/transaction"
 	"github.com/vulpemventures/ocean/internal/core/domain"
 	"github.com/vulpemventures/ocean/internal/core/ports"
-	wallet "github.com/vulpemventures/ocean/pkg/wallet"
+	"github.com/vulpemventures/ocean/pkg/wallet"
 	singlesig "github.com/vulpemventures/ocean/pkg/wallet/single-sig"
 )
 
@@ -90,7 +90,9 @@ func (ts *TransactionService) GetTransactionInfo(
 		if err != nil {
 			return nil, err
 		}
-		tx = &res[0]
+		if len(res) != 0 {
+			tx = &res[0]
+		}
 	}
 	return (*TransactionInfo)(tx), nil
 }

--- a/internal/interfaces/grpc/interceptor/interceptor.go
+++ b/internal/interfaces/grpc/interceptor/interceptor.go
@@ -10,6 +10,7 @@ func UnaryInterceptor() grpc.ServerOption {
 	return grpc.UnaryInterceptor(
 		middleware.ChainUnaryServer(
 			unaryLogger,
+			unaryPanicRecoveryInterceptor(),
 		),
 	)
 }
@@ -19,6 +20,7 @@ func StreamInterceptor() grpc.ServerOption {
 	return grpc.StreamInterceptor(
 		middleware.ChainStreamServer(
 			streamLogger,
+			streamPanicRecoveryInterceptor(),
 		),
 	)
 }

--- a/internal/interfaces/grpc/interceptor/panic.go
+++ b/internal/interfaces/grpc/interceptor/panic.go
@@ -1,0 +1,45 @@
+package grpc_interceptor
+
+import (
+	"context"
+	"runtime/debug"
+
+	log "github.com/sirupsen/logrus"
+	"google.golang.org/grpc"
+)
+
+func unaryPanicRecoveryInterceptor() grpc.UnaryServerInterceptor {
+	return func(
+		ctx context.Context,
+		req interface{},
+		info *grpc.UnaryServerInfo,
+		handler grpc.UnaryHandler,
+	) (interface{}, error) {
+		defer func() {
+			if r := recover(); r != nil {
+				log.Errorf("panic-recovery middleware recovered from panic: %v", r)
+				log.Tracef("panic-recovery middleware recovered from panic: %v", string(debug.Stack()))
+			}
+		}()
+
+		return handler(ctx, req)
+	}
+}
+
+func streamPanicRecoveryInterceptor() grpc.StreamServerInterceptor {
+	return func(
+		srv interface{},
+		stream grpc.ServerStream,
+		info *grpc.StreamServerInfo,
+		handler grpc.StreamHandler,
+	) error {
+		defer func() {
+			if r := recover(); r != nil {
+				log.Errorf("panic-recovery middleware recovered from panic: %v", r)
+				log.Tracef("panic-recovery middleware recovered from panic: %v", string(debug.Stack()))
+			}
+		}()
+
+		return handler(srv, stream)
+	}
+}


### PR DESCRIPTION
Noticed in ocean bellow error that caused server crash:

```
panic: runtime error: index out of range [0] with length 0
2024-08-30T08:00:18.975021059Z 
goroutine 204 [running]:
github.com/vulpemventures/ocean/internal/core/application.(*TransactionService).GetTransactionInfo(0xc000209780, {0x126cab0, 0xc0020342a0}, {0xc00226b140, 0x40})
/home/runner/work/ocean/ocean/internal/core/application/transaction_service.go:93 +0xec
github.com/vulpemventures/ocean/internal/interfaces/grpc/handler.(*transaction).GetTransaction(0xc00018e678, {0x126cab0, 0xc0020342a0}, 0xe61a00?)
/home/runner/work/ocean/ocean/internal/interfaces/grpc/handler/transaction.go:31 +0x178
github.com/vulpemventures/ocean/api-spec/protobuf/gen/go/ocean/v1._TransactionService_GetTransaction_Handler.func1({0x126cab0?, 0xc0020342a0?}, {0xf2f300?, 0xc000189380?})
/home/runner/work/ocean/ocean/api-spec/protobuf/gen/go/ocean/v1/transaction_grpc.pb.go:356 +0xcb
github.com/vulpemventures/ocean/internal/interfaces/grpc/interceptor.unaryLogger({0x126cab0, 0xc0020342a0}, {0xf2f300, 0xc000189380}, 0x18?, 0xc0020f3ce0)
/home/runner/work/ocean/ocean/internal/interfaces/grpc/interceptor/logger.go:17 +0xa9
github.com/vulpemventures/ocean/internal/interfaces/grpc.(*service).start.UnaryInterceptor.ChainUnaryServer.func2.1.1({0x126cab0?, 0xc0020342a0?}, {0xf2f300?, 0xc000189380?})
/home/runner/go/pkg/mod/github.com/grpc-ecosystem/go-grpc-middleware@v1.3.0/chain.go:25 +0x34
github.com/vulpemventures/ocean/internal/interfaces/grpc.(*service).start.UnaryInterceptor.ChainUnaryServer.func2({0x126cab0, 0xc0020342a0}, {0xf2f300, 0xc000189380}, 0x416525?, 0x70?)
/home/runner/go/pkg/mod/github.com/grpc-ecosystem/go-grpc-middleware@v1.3.0/chain.go:34 +0xb8
github.com/vulpemventures/ocean/api-spec/protobuf/gen/go/ocean/v1._TransactionService_GetTransaction_Handler({0xfbaa40, 0xc00018e678}, {0x126cab0, 0xc0020342a0}, 0xc00225f960, 0xc0003b6d20)
/home/runner/work/ocean/ocean/api-spec/protobuf/gen/go/ocean/v1/transaction_grpc.pb.go:358 +0x143
google.golang.org/grpc.(*Server).processUnaryRPC(0xc0003b45a0, {0x1272320, 0xc0002fb520}, 0xc000219320, 0xc0003b7710, 0x1909360, 0x0)
/home/runner/go/pkg/mod/google.golang.org/grpc@v1.53.0/server.go:1336 +0xd16
google.golang.org/grpc.(*Server).handleStream(0xc0003b45a0, {0x1272320, 0xc0002fb520}, 0xc000219320, 0x0)
/home/runner/go/pkg/mod/google.golang.org/grpc@v1.53.0/server.go:1704 +0x9da
google.golang.org/grpc.(*Server).serveStreams.func1.2()
/home/runner/go/pkg/mod/google.golang.org/grpc@v1.53.0/server.go:965 +0x8d
created by google.golang.org/grpc.(*Server).serveStreams.func1 in goroutine 93

```

This adds panic recovery interceptor and it adds check in GetTransactionInfo that prevents:
`panic: runtime error: index out of range [0] with length 0`

@tiero @altafan 